### PR TITLE
Block method by default: TRACE

### DIFF
--- a/base/etc/nginx/conf.d/location/10-block-method.conf
+++ b/base/etc/nginx/conf.d/location/10-block-method.conf
@@ -1,0 +1,3 @@
+if ($request_method ~ ^(TRACE)$) {
+  return 405;
+}


### PR DESCRIPTION
**Overview**

Disable the TRACE/TRACK methods on proxy and origin webservers to avoid information disclosure.

**How to test**

```bash
# Run the image
$ docker run -it -p8080:8080 skpr/nginx-drupal:dev-v2-latest-amd64

# Test with a TRACE request
$ curl -X TRACE http://localhost:8080/
<html>
<head><title>405 Not Allowed</title></head>
<body>
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
</html>
```