### PR TITLE
Support on-demand asset aggregate generation

### DIFF
--- a/drupal/etc/nginx/conf.d/location/20-drupal.conf
+++ b/drupal/etc/nginx/conf.d/location/20-drupal.conf
@@ -3,8 +3,8 @@ location ~* ^.+\.php$ {
   return 403;
 }
 
-# Passes style generation to PHP.
-location ~ ^/sites/.*/files/styles/ {
+# Passes image style and asset generation to PHP.
+location ~ ^/sites/.*/files/css|js|styles/ {
   try_files $uri @rewrite;
 }
 


### PR DESCRIPTION
In Drupal 10.1 nginx is sending a 404 response for aggregated CSS and JS files. This is due to a change of behaviour in [CSS and JavaScript aggregation performance improvements](https://www.drupal.org/node/3301716).

Tested in 9.5 and 10.1.