### PR TITLE
Restore support for on-demand asset aggregate generation

### DIFF
--- a/drupal/etc/nginx/conf.d/location/20-drupal.conf
+++ b/drupal/etc/nginx/conf.d/location/20-drupal.conf
@@ -3,8 +3,8 @@ location ~* ^.+\.php$ {
   return 403;
 }
 
-# Passes style generation to PHP.
-location ~ ^/sites/.*/files/styles/ {
+# Passes image style and asset generation to PHP.
+location ~ ^/sites/.*/files/(css|js|styles)/ {
   try_files $uri @rewrite;
 }
 


### PR DESCRIPTION
See #13, #15

Previous attempt was missing parentheses, so any path with `js` or `styles`, not necessarily within `/sites/default/files`, was passed to Drupal.