### PR TITLE
Block the TRACK method by default

### DIFF
--- a/base/etc/nginx/conf.d/location/10-block-method.conf
+++ b/base/etc/nginx/conf.d/location/10-block-method.conf
@@ -1,3 +1,7 @@
 if ($request_method ~ ^(TRACE)$) {
   return 405;
 }
+
+if ($request_method ~ ^(TRACK)$) {
+  return 405;
+}


### PR DESCRIPTION
```
$ docker run --detach -it -p 8080:8080 skpr/nginx-drupal:dev-v2-latest-amd64     
c74aeee3eedde6b8932727a014d25a3f7325a2e1fc2d65260d87d811aae92967

$ curl -X TRACK http://localhost:8080/
<html>
<head><title>405 Not Allowed</title></head>
<body>
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
</html>
```