### PR TITLE
Split out css/js generation. Fix query string bug.

### DIFF
--- a/drupal/etc/nginx/conf.d/location/20-drupal.conf
+++ b/drupal/etc/nginx/conf.d/location/20-drupal.conf
@@ -3,7 +3,7 @@ location ~* ^.+\.php$ {
   return 403;
 }
 
-# Passes image style and asset generation to PHP.
+# Passes image style generation to PHP.
 location ~ ^/sites/.*/files/styles/ {
   try_files $uri @rewrite;
   # @todo Investigate using the same approach as css and js asset generation.

--- a/drupal/etc/nginx/conf.d/location/20-drupal.conf
+++ b/drupal/etc/nginx/conf.d/location/20-drupal.conf
@@ -4,8 +4,20 @@ location ~* ^.+\.php$ {
 }
 
 # Passes image style and asset generation to PHP.
-location ~ ^/sites/.*/files/(css|js|styles)/ {
+location ~ ^/sites/.*/files/styles/ {
   try_files $uri @rewrite;
+  # @todo Investigate using the same approach as css and js asset generation.
+  # try_files $uri /index.php?$query_string;
+}
+
+# Passes requests to Drupal for generation if does not exist on filesystem.
+location ~ ^/sites/.*/files/css/ {
+  try_files $uri /index.php?$query_string;
+}
+
+# Passes requests to Drupal for generation if does not exist on filesystem.
+location ~ ^/sites/.*/files/js/ {
+  try_files $uri /index.php?$query_string;
 }
 
 # Access to these files go via Drupal permissions.


### PR DESCRIPTION
* Split out css/js generation into separate location blocks
* Fix query string bug. (`try_files $uri @rewrite;` vs `try_files $uri /index.php?$query_string;`)