### PR TITLE
Adds X-Robots-Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Images for applications which require Nginx (Drupal, PHP etc).
 ## Documentation
 
 * [Static Status Codes](/docs/static_status_codes.md)
+* [robots.txt](/docs/robots.md)
 
 ## Streams
 

--- a/base/etc/nginx/conf.d/header/robots.conf
+++ b/base/etc/nginx/conf.d/header/robots.conf
@@ -1,0 +1,1 @@
+add_header X-Robots-Tag $header_x_robots_tag always;

--- a/base/etc/nginx/default.conf
+++ b/base/etc/nginx/default.conf
@@ -26,6 +26,10 @@ map $host$uri $redirectdomain {
   include /etc/nginx/redirects.conf;
 }
 
+map $request_uri $header_x_robots_tag {
+  include /etc/nginx/robots.conf;
+}
+
 include /etc/nginx/http.conf;
 
 server {

--- a/base/etc/nginx/robots.conf
+++ b/base/etc/nginx/robots.conf
@@ -1,0 +1,3 @@
+# Can be overridden with robots configuration eg.
+#
+#   ~*/error.html "noindex, nofollow";

--- a/docs/robots.md
+++ b/docs/robots.md
@@ -1,0 +1,36 @@
+Robots.txt
+==========
+
+This document outlines how robots.txt is managed for our Skpr image suite.
+
+## Hardening
+
+Developers often list the locations of hidden files or directories in robots.txt to prevent these locations from showing up in search engine results. However, the opposite effect is achieved when human users browse this file and read its contents.
+
+Below is a list of steps to harden your application configuration:
+
+* Remove sensitive paths from your applications `robots.txt` file.
+* Leverage `X-Robots-Tag` tag to hide sensitive paths instead (see below).
+
+## X-Robots-Tag
+
+The X-Robots-Tag is an HTTP header sent from a web server that contains the directives for web crawlers such as Googlebot.
+
+The following header is an alternative to the standard robots.txt approach and allows for development teams to obfuscate sensitives paths.
+
+This configuration is managed using the `/etc/nginx/robots.conf` file.
+
+The configuration below sets the `X-Robots-Tag` header for all pages under `/admin` path.
+
+```
+~*/admin/(.*) "noindex, nofollow";
+```
+
+**How do I opt out?**
+
+Clients can opt out of this header by adding the following to their Nginx Dockerfile build:
+
+```
+# Removes all X-Robots-Tag rules.
+RUN echo "" > /etc/nginx/conf.d/header/robots.conf
+```

--- a/drupal/etc/nginx/robots.conf
+++ b/drupal/etc/nginx/robots.conf
@@ -1,0 +1,41 @@
+# We want assets under the "not allowed" category to not have the X-Robots-Tag header.
+# Having these paths come first and setting the value to empty means they will not have the header.
+~*/core/(.*).css      "";
+~*/core/(.*).js       "";
+~*/core/(.*).gif      "";
+~*/core/(.*).jpg      "";
+~*/core/(.*).jpeg     "";
+~*/core/(.*).png      "";
+~*/core/(.*).svg      "";
+~*/profiles/(.*).css  "";
+~*/profiles/(.*).js   "";
+~*/profiles/(.*).gif  "";
+~*/profiles/(.*).jpg  "";
+~*/profiles/(.*).jpeg "";
+~*/profiles/(.*).png  "";
+~*/profiles/(.*).svg  "";
+# Not allowed
+~*/core/(.*)                    "noindex, nofollow";
+~*/profiles/(.*)                "noindex, nofollow";
+~*/README.txt                   "noindex, nofollow";
+~*/web.config                   "noindex, nofollow";
+~*/admin/(.*)                   "noindex, nofollow";
+~*/comment/reply/(.*)           "noindex, nofollow";
+~*/filter/tips/(.*)             "noindex, nofollow";
+~*/node/add/(.*)                "noindex, nofollow";
+~*/search/(.*)                  "noindex, nofollow";
+~*/user/register/(.*)           "noindex, nofollow";
+~*/user/password/(.*)           "noindex, nofollow";
+~*/user/login/(.*)              "noindex, nofollow";
+~*/user/logout/(.*)             "noindex, nofollow";
+~*/index.php/admin/(.*)         "noindex, nofollow";
+~*/index.php/comment/reply/(.*) "noindex, nofollow";
+~*/index.php/filter/tips/(.*)   "noindex, nofollow";
+~*/index.php/node/add/(.*)      "noindex, nofollow";
+~*/index.php/search/(.*)        "noindex, nofollow";
+~*/index.php/user/register/(.*) "noindex, nofollow";
+~*/index.php/user/password/(.*) "noindex, nofollow";
+~*/index.php/user/login/(.*)    "noindex, nofollow";
+~*/index.php/user/logout/(.*)   "noindex, nofollow";
+~*/error.html                   "noindex, nofollow";
+~*/styleguide/(.*)              "noindex, nofollow";

--- a/drupal/tests/test.go
+++ b/drupal/tests/test.go
@@ -13,6 +13,9 @@ func main() {
 	var errs []error
 
 	tests := []Test{
+		// Tests for header: X-Robots-Tag.
+		noResponseHeader("http://127.0.0.1:8080", "X-Robots-Tag"),
+		hasResponseHeader("http://127.0.0.1:8080/admin/people", "X-Robots-Tag"),
 		// Blocking rules.
 		hasStatusCode("http://127.0.0.1:8080/index.PHP", 403),
 		hasStatusCode("http://127.0.0.1:8080/tag", 200),
@@ -38,6 +41,38 @@ func main() {
 		}
 
 		os.Exit(1)
+	}
+}
+
+// Check if a url has a specified header.
+func hasResponseHeader(url, header string) Test {
+	return func() error {
+		resp, err := http.Get(url)
+		if err != nil {
+			return fmt.Errorf("failed to get host: %w", err)
+		}
+
+		if _, ok := resp.Header[header]; !ok {
+			return fmt.Errorf("header %s does not exist for page %s", url, header)
+		}
+
+		return nil
+	}
+}
+
+// Check if a url does not have a specified header.
+func noResponseHeader(url, header string) Test {
+	return func() error {
+		resp, err := http.Get(url)
+		if err != nil {
+			return fmt.Errorf("failed to get host: %w", err)
+		}
+
+		if _, ok := resp.Header[header]; ok {
+			return fmt.Errorf("header %s does exist for page %s", url, header)
+		}
+
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Overview

(Built on top of: https://github.com/skpr/image-nginx/pull/36)

We have had multiple clients who have been asked by pen testers to **limit the amount of sensitive paths in their robots.txt file** and implement a **X-Robots-Tag** header instead.

Centralising this approach to our Nginx base images means that our customers will be secure by default and not have to implement this approach on a project by project basis.

## Impact

Minimal given we are not removing any functionality and only adding a header to existing pages which should not be indexed by robots.

## Opt Out

Clients could opt out of this change by adding the following to their Nginx Dockerfile:

```
RUN rm -f /etc/nginx/conf.d/header/robots.conf
```