### PR TITLE
Replace deprecated Feature-Policy header with Permissions-Policy

### DIFF
--- a/base/etc/nginx/conf.d/header/feature.conf
+++ b/base/etc/nginx/conf.d/header/feature.conf
@@ -1,3 +1,0 @@
-# Feature Policy will allow a site to enable or disable certain browser features and APIs in the interest of better security and privacy.
-# https://scotthelme.co.uk/a-new-security-header-feature-policy
-add_header Feature-Policy "geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'self'; vibrate 'none'; fullscreen 'self'; payment 'none';";

--- a/base/etc/nginx/conf.d/header/feature.conf
+++ b/base/etc/nginx/conf.d/header/feature.conf
@@ -1,0 +1,1 @@
+add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=()";

--- a/base/etc/nginx/conf.d/header/permissions.conf
+++ b/base/etc/nginx/conf.d/header/permissions.conf
@@ -1,1 +1,0 @@
-add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), microphone=(), payment=(), usb=()";

--- a/base/etc/nginx/conf.d/header/permissions.conf
+++ b/base/etc/nginx/conf.d/header/permissions.conf
@@ -1,0 +1,1 @@
+add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), microphone=(), payment=(), usb=()";


### PR DESCRIPTION
> Note: Permissions Policy used to be called Feature Policy. The name has changed, and so has the HTTP header syntax, so bear this in mind if you have used Feature Policy in the past, and check the browser support tables. The <iframe allow=" ... "> syntax has stayed the same.

The following feature policy directives were removed in permissions policy:

* notifications 
* push
* speaker
* vibrate