### PR TITLE
Improve security headers based on headers.dev analysis

### DIFF
--- a/base/etc/nginx/conf.d/header/cross-origin-opener-policy.conf
+++ b/base/etc/nginx/conf.d/header/cross-origin-opener-policy.conf
@@ -1,0 +1,4 @@
+# Cross-Origin-Opener-Policy prevents other origins from gaining a reference to this window.
+# same-origin-allow-popups is used to preserve OAuth and payment popup flows.
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;

--- a/base/etc/nginx/conf.d/header/cross-origin-resource-policy.conf
+++ b/base/etc/nginx/conf.d/header/cross-origin-resource-policy.conf
@@ -1,0 +1,4 @@
+# Cross-Origin-Resource-Policy controls which origins can include this resource.
+# same-site allows subdomains on the same site (e.g. CDN serving from same eTLD+1).
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
+add_header Cross-Origin-Resource-Policy "same-site" always;

--- a/base/etc/nginx/conf.d/header/feature.conf
+++ b/base/etc/nginx/conf.d/header/feature.conf
@@ -1,3 +1,4 @@
-# Feature Policy will allow a site to enable or disable certain browser features and APIs in the interest of better security and privacy.
-# https://scotthelme.co.uk/a-new-security-header-feature-policy
-add_header Feature-Policy "geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'self'; vibrate 'none'; fullscreen 'self'; payment 'none';" always;
+# Permissions-Policy controls which browser features and APIs are available to the page.
+# Replaces the deprecated Feature-Policy header.
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy
+add_header Permissions-Policy "geolocation=(), midi=(), notifications=(), push=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(self), vibrate=(), fullscreen=(self), payment=()" always;

--- a/base/etc/nginx/conf.d/header/x-permitted-cross-domain-policies.conf
+++ b/base/etc/nginx/conf.d/header/x-permitted-cross-domain-policies.conf
@@ -1,0 +1,3 @@
+# X-Permitted-Cross-Domain-Policies restricts Adobe Flash and PDF cross-domain data requests.
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Permitted-Cross-Domain-Policies
+add_header X-Permitted-Cross-Domain-Policies "none" always;

--- a/base/etc/nginx/conf.d/location/10-error-pages.conf
+++ b/base/etc/nginx/conf.d/location/10-error-pages.conf
@@ -2,7 +2,7 @@ location /error-pages/ {
   alias /etc/nginx/error-pages/;
   
   # Prevent scripts getting into our sub_filter.
-  add_header Content-Security-Policy "script-src 'none';";
+  add_header Content-Security-Policy "script-src 'none'; base-uri 'none'; upgrade-insecure-requests;";
 
   add_header X-Trace-ID $request_id;
 

--- a/drupal/tests/test.go
+++ b/drupal/tests/test.go
@@ -23,9 +23,18 @@ func main() {
 		// Test for header: Referrer-Policy.
 		hasResponseHeader("http://127.0.0.1:8080", "Referrer-Policy"),
 		hasResponseHeader("http://127.0.0.1:8080/index.PHP", "Referrer-Policy"),
-		// Test for header: Feature-Policy.
-		hasResponseHeader("http://127.0.0.1:8080", "Feature-Policy"),
-		hasResponseHeader("http://127.0.0.1:8080/index.PHP", "Feature-Policy"),
+		// Test for header: Permissions-Policy.
+		hasResponseHeader("http://127.0.0.1:8080", "Permissions-Policy"),
+		hasResponseHeader("http://127.0.0.1:8080/index.PHP", "Permissions-Policy"),
+		// Test for header: Cross-Origin-Opener-Policy.
+		hasResponseHeader("http://127.0.0.1:8080", "Cross-Origin-Opener-Policy"),
+		hasResponseHeader("http://127.0.0.1:8080/index.PHP", "Cross-Origin-Opener-Policy"),
+		// Test for header: Cross-Origin-Resource-Policy.
+		hasResponseHeader("http://127.0.0.1:8080", "Cross-Origin-Resource-Policy"),
+		hasResponseHeader("http://127.0.0.1:8080/index.PHP", "Cross-Origin-Resource-Policy"),
+		// Test for header: X-Permitted-Cross-Domain-Policies.
+		hasResponseHeader("http://127.0.0.1:8080", "X-Permitted-Cross-Domain-Policies"),
+		hasResponseHeader("http://127.0.0.1:8080/index.PHP", "X-Permitted-Cross-Domain-Policies"),
 		// Test for header: Strict-Transport-Security.
 		hasResponseHeader("http://127.0.0.1:8080", "Strict-Transport-Security"),
 		hasResponseHeader("http://127.0.0.1:8080/foo", "Strict-Transport-Security"),


### PR DESCRIPTION
## Summary

- Migrate deprecated `Feature-Policy` header to `Permissions-Policy` (new syntax: `feature=()` instead of `feature 'none'`)
- Add `Cross-Origin-Opener-Policy: same-origin-allow-popups` — prevents cross-origin window references while preserving OAuth/payment popup flows
- Add `Cross-Origin-Resource-Policy: same-site` — restricts resource embedding to same-site origins (allows CDN subdomains)
- Add `X-Permitted-Cross-Domain-Policies: none` — blocks legacy Flash/Adobe cross-domain requests
- Extend error page `Content-Security-Policy` with `base-uri 'none'` and `upgrade-insecure-requests`

Identified via https://headers.dev/analyze?url=www.previousnext.com.au

## Test plan

- [ ] Verify nginx config is valid (`nginx -t`)
- [ ] Check `Permissions-Policy` header is present and `Feature-Policy` is gone
- [ ] Check `Cross-Origin-Opener-Policy`, `Cross-Origin-Resource-Policy`, and `X-Permitted-Cross-Domain-Policies` headers are present
- [ ] Re-run https://headers.dev/analyze?url=www.previousnext.com.au after deploy to confirm warnings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)